### PR TITLE
Make the map movement handler use history API's replace state if possible

### DIFF
--- a/packages/web/modules/InteractiveMap/components/Map/Map.tsx
+++ b/packages/web/modules/InteractiveMap/components/Map/Map.tsx
@@ -75,7 +75,12 @@ export const Map: React.FunctionComponent<Props> = props => {
     const { lat, lng } = leafletMap.getCenter();
     const zoom = leafletMap.getZoom();
 
-    location.hash = `${lat};${lng};${zoom};${hash}`;
+    const location_hash = `${lat};${lng};${zoom};${hash}`;
+    if( history && typeof history.replaceState === 'function' ){
+      history.replaceState("","","#"+location_hash);
+    }else{
+      location.hash = location_hash;
+    }
   }
 
   React.useEffect(() => {


### PR DESCRIPTION
The history.replaceState function will update the browser's hash without adding a new entry to the history list.
Before: 
Browse to the map page, zoom/scroll the map ten times. Click the back button ten times to leave the map.
After:
Browse to the map page, zoom/scroll the map ten times. Click the back button once to leave the map.