### PR TITLE
fixed originId of node 700

### DIFF
--- a/packages/web/modules/InteractiveMap/data/nodes.ts
+++ b/packages/web/modules/InteractiveMap/data/nodes.ts
@@ -3545,7 +3545,7 @@ export const nodes: Node[] = [
     x: -113215.828125,
     y: -44145,
     z: 16295.931640625,
-    originId: "PL_RN__700",
+    originId: "PL_RN_700",
     obstructed: false,
     purity: "pure",
     type: "coal",


### PR DESCRIPTION
I was using your nodes file to do some calculations of my own and I noticed that one of the nodes has an extra underscore in the name. I assume this is a typo/error of some sort.